### PR TITLE
Fix mingw-w64 cross compilation by using lowercase windows.h include

### DIFF
--- a/src/testcommon/mmap.cpp
+++ b/src/testcommon/mmap.cpp
@@ -7,7 +7,7 @@
 #include <system_error>
 
 #ifdef _WIN32
-  #include <Windows.h>
+  #include <windows.h>
 #else
   #include <cerrno>
 

--- a/src/testcommon/timer.h
+++ b/src/testcommon/timer.h
@@ -29,7 +29,7 @@ public:
 
 #else
 
-#include <Windows.h>
+#include <windows.h>
 
 class Timer {
 	LARGE_INTEGER m_start;

--- a/src/vszimg/vszimg.c
+++ b/src/vszimg/vszimg.c
@@ -5,7 +5,7 @@
 #include <string.h>
 
 #ifdef _WIN32
-  #include <Windows.h>
+  #include <windows.h>
   typedef CRITICAL_SECTION vszimg_mutex_t;
 
   static int vszimg_mutex_init(vszimg_mutex_t *mutex) { InitializeCriticalSection(mutex); return 0;  }


### PR DESCRIPTION
This fixes cross-compilation to Windows on Linux.