### PR TITLE
Make colorspace validation function public

### DIFF
--- a/src/zimg/api/zimg.cpp
+++ b/src/zimg/api/zimg.cpp
@@ -598,6 +598,23 @@ zimg_error_code_e zimg_filter_graph_process(const zimg_filter_graph *ptr, const 
 #undef EX_BEGIN
 #undef EX_END
 
+zimg_error_code_e zimg_validate_image_format(zimg_image_format *ptr)
+{
+	using namespace zimg::colorspace;
+
+	zassert_d(ptr, "null pointer");
+
+	if (ptr->width == 0 || ptr->height == 0 || ptr->pixel_type == static_cast<zimg_pixel_type_e>(-1))
+		return ZIMG_ERROR_LOGIC;
+
+	ColorspaceDefinition csp = zimg::colorspace::ColorspaceDefinition{};
+	csp.matrix = translate_matrix(ptr->matrix_coefficients);
+	csp.transfer = translate_transfer(ptr->transfer_characteristics);
+	csp.primaries = translate_primaries(ptr->color_primaries);
+
+	return zimg::colorspace::is_valid_csp(*(const_cast<const decltype(&csp)>(&csp))) ? ZIMG_ERROR_SUCCESS : ZIMG_ERROR_COLOR_SPACE_DEFINITION;
+}
+
 void zimg_image_format_default(zimg_image_format *ptr, unsigned version)
 {
 	zassert_d(ptr, "null pointer");

--- a/src/zimg/api/zimg.h
+++ b/src/zimg/api/zimg.h
@@ -90,6 +90,7 @@ typedef enum zimg_error_code_e {
 	ZIMG_ERROR_COLOR_FAMILY_MISMATCH = ZIMG_ERROR_LOGIC + 2, /**< Illegal combination of color family and matrix coefficients. */
 	ZIMG_ERROR_IMAGE_NOT_DIVISIBLE   = ZIMG_ERROR_LOGIC + 3, /**< Image dimension does not fit a modulo constraint. */
 	ZIMG_ERROR_BIT_DEPTH_OVERFLOW    = ZIMG_ERROR_LOGIC + 4, /**< Bit depth greater than underlying storage format. */
+	ZIMG_ERROR_COLOR_SPACE_DEFINITION= ZIMG_ERROR_LOGIC + 5, /**< Invalid combination of matrix_coefficients, color_primaries, and/or transfer_characteristics values */
 
 	/**
 	 * A function parameter was passed an illegal value.
@@ -609,6 +610,14 @@ void zimg_image_format_default(zimg_image_format *ptr, unsigned version);
  */
 ZIMG_VISIBILITY
 void zimg_graph_builder_params_default(zimg_graph_builder_params *ptr, unsigned version);
+
+/*
+ * Validate whether image format structure can be safely processed.
+ *
+ * @param[out] ptr structure to be initialized
+ */
+ZIMG_VISIBILITY
+zimg_error_code_e zimg_validate_image_format(zimg_image_format *ptr);
 
 /**
  * Create a graph converting the specified formats.

--- a/src/zimg/colorspace/colorspace.h
+++ b/src/zimg/colorspace/colorspace.h
@@ -110,6 +110,44 @@ constexpr bool operator!=(const ColorspaceDefinition &a, const ColorspaceDefinit
 }
 
 
+constexpr bool is_valid_2020cl(const ColorspaceDefinition &csp)
+{
+	return csp.matrix == MatrixCoefficients::REC_2020_CL && csp.transfer == TransferCharacteristics::REC_709;
+}
+
+constexpr bool is_valid_ictcp(const ColorspaceDefinition &csp)
+{
+	return csp.matrix == MatrixCoefficients::REC_2100_ICTCP &&
+		(csp.transfer == TransferCharacteristics::ST_2084 || csp.transfer == TransferCharacteristics::ARIB_B67) &&
+		csp.primaries == ColorPrimaries::REC_2020;
+}
+
+constexpr bool is_valid_lms(const ColorspaceDefinition &csp)
+{
+	return csp.matrix == MatrixCoefficients::REC_2100_LMS &&
+		(csp.transfer == TransferCharacteristics::LINEAR || csp.transfer == TransferCharacteristics::ST_2084 || csp.transfer == TransferCharacteristics::ARIB_B67) &&
+		csp.primaries == ColorPrimaries::REC_2020;
+}
+
+constexpr bool is_valid_csp(const ColorspaceDefinition &csp)
+{
+	// 1. Require matrix to be set if transfer is set.
+	// 2. Require transfer to be set if primaries is set.
+	// 3. Check requirements for Rec.2020 CL.
+	// 4. Check requirements for chromaticity-derived NCL matrix.
+	// 5. Check requirements for chromaticity-derived CL matrix.
+	// 6. Check requirements for Rec.2100 ICtCp.
+	// 7. Check requirements for Rec.2100 LMS.
+	return !(csp.matrix == MatrixCoefficients::UNSPECIFIED && csp.transfer != TransferCharacteristics::UNSPECIFIED) &&
+		!(csp.transfer == TransferCharacteristics::UNSPECIFIED && csp.primaries != ColorPrimaries::UNSPECIFIED) &&
+		!(csp.matrix == MatrixCoefficients::REC_2020_CL && !is_valid_2020cl(csp)) &&
+		!(csp.matrix == MatrixCoefficients::CHROMATICITY_DERIVED_NCL && csp.primaries == ColorPrimaries::UNSPECIFIED) &&
+		!(csp.matrix == MatrixCoefficients::CHROMATICITY_DERIVED_CL && csp.primaries == ColorPrimaries::UNSPECIFIED) &&
+		!(csp.matrix == MatrixCoefficients::REC_2100_ICTCP && !is_valid_ictcp(csp)) &&
+		!(csp.matrix == MatrixCoefficients::REC_2100_LMS && !is_valid_lms(csp));
+}
+
+
 struct ColorspaceConversion {
 	unsigned width;
 	unsigned height;

--- a/src/zimg/colorspace/graph.cpp
+++ b/src/zimg/colorspace/graph.cpp
@@ -66,44 +66,6 @@ EnumRange<ColorPrimaries> all_primaries()
 	return{ ColorPrimaries::UNSPECIFIED, ColorPrimaries::DCI_P3_D65 };
 }
 
-constexpr bool is_valid_2020cl(const ColorspaceDefinition &csp)
-{
-	return csp.matrix == MatrixCoefficients::REC_2020_CL && csp.transfer == TransferCharacteristics::REC_709;
-}
-
-constexpr bool is_valid_ictcp(const ColorspaceDefinition &csp)
-{
-	return csp.matrix == MatrixCoefficients::REC_2100_ICTCP &&
-		(csp.transfer == TransferCharacteristics::ST_2084 || csp.transfer == TransferCharacteristics::ARIB_B67) &&
-		csp.primaries == ColorPrimaries::REC_2020;
-}
-
-constexpr bool is_valid_lms(const ColorspaceDefinition &csp)
-{
-	return csp.matrix == MatrixCoefficients::REC_2100_LMS &&
-		(csp.transfer == TransferCharacteristics::LINEAR || csp.transfer == TransferCharacteristics::ST_2084 || csp.transfer == TransferCharacteristics::ARIB_B67) &&
-		csp.primaries == ColorPrimaries::REC_2020;
-}
-
-constexpr bool is_valid_csp(const ColorspaceDefinition &csp)
-{
-	// 1. Require matrix to be set if transfer is set.
-	// 2. Require transfer to be set if primaries is set.
-	// 3. Check requirements for Rec.2020 CL.
-	// 4. Check requirements for chromaticity-derived NCL matrix.
-	// 5. Check requirements for chromaticity-derived CL matrix.
-	// 6. Check requirements for Rec.2100 ICtCp.
-	// 7. Check requirements for Rec.2100 LMS.
-	return !(csp.matrix == MatrixCoefficients::UNSPECIFIED && csp.transfer != TransferCharacteristics::UNSPECIFIED) &&
-		!(csp.transfer == TransferCharacteristics::UNSPECIFIED && csp.primaries != ColorPrimaries::UNSPECIFIED) &&
-		!(csp.matrix == MatrixCoefficients::REC_2020_CL && !is_valid_2020cl(csp)) &&
-		!(csp.matrix == MatrixCoefficients::CHROMATICITY_DERIVED_NCL && csp.primaries == ColorPrimaries::UNSPECIFIED) &&
-		!(csp.matrix == MatrixCoefficients::CHROMATICITY_DERIVED_CL && csp.primaries == ColorPrimaries::UNSPECIFIED) &&
-		!(csp.matrix == MatrixCoefficients::REC_2100_ICTCP && !is_valid_ictcp(csp)) &&
-		!(csp.matrix == MatrixCoefficients::REC_2100_LMS && !is_valid_lms(csp));
-}
-
-
 struct ColorspaceHash {
 	bool operator()(const ColorspaceDefinition &csp) const
 	{


### PR DESCRIPTION
Hi, I thought of basically making the `is_valid_csp` function public: I'd like to be able of detecting an invalid configuration early, rather than during graph building. In this way I could either reset the format fields, and still get a conversion running (albeit incorrect) or print a nicer message to the user, and advise what went wrong.

I had to do a bit of code shuffling which is not ideal, and the const cast is definitely ugly, if you have suggestions on how to improve this, I'll gladly accept any advice.