### PR TITLE
libm_wrapper: define __CRT__NO_INLINE before math.h

### DIFF
--- a/src/zimg/common/libm_wrapper.cpp
+++ b/src/zimg/common/libm_wrapper.cpp
@@ -1,5 +1,6 @@
-#include <math.h>
 #include "libm_wrapper.h"
+#define __CRT__NO_INLINE 1
+#include <math.h>
 
 float (*zimg_x_expf)(float) = expf;
 float (*zimg_x_logf)(float) = logf;


### PR DESCRIPTION
math.h might define certain functions as inline and that can cause  issues when trying to pull the function pointers to those functions with mingw-w64 gcc/clang