### PR TITLE
Add `use_scene_referred` to `zimg_graph_builder_params`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+3.0.5
+api: add 'use_scene_referred' flag to zimg_graph_builder_params
+
 3.0.4
 colorspace: fix ARIB STD-B67 constant-luminance EOTF (introduced in 2.6)
 colorspace: filter negative values from sRGB-like transfer functions

--- a/doc/example/hdr_example.cpp
+++ b/doc/example/hdr_example.cpp
@@ -70,7 +70,7 @@ const ArgparseOption program_switches[] = {
 	{ OPTION_FLOAT,  "l", "luminance", offsetof(Arguments, luminance), nullptr, "legacy peak brightness (cd/m^2)" },
 	{ OPTION_USER1,  "k", "key",       offsetof(Arguments, mask_key),  decode_mask_key, "HDR color key (RRGGBB hex string)" },
 	{ OPTION_STRING, "m", "mask",      offsetof(Arguments, hdrpath),   nullptr, "HDR difference mask" },
-	{ OPTION_STRING, "s", "sceneref",  offsetof(Arguments, hdrpath),   nullptr, "use scene-referred transfer functions" },
+	{ OPTION_STRING, "s", "sceneref",  offsetof(Arguments, scene_referred),   nullptr, "use scene-referred transfer functions" },
 	{ OPTION_NULL }
 };
 

--- a/doc/example/hdr_example.cpp
+++ b/doc/example/hdr_example.cpp
@@ -60,6 +60,7 @@ struct Arguments {
 	char fast;
 	char hlg;
 	char wcg;
+	char scene_referred;
 };
 
 const ArgparseOption program_switches[] = {
@@ -69,6 +70,7 @@ const ArgparseOption program_switches[] = {
 	{ OPTION_FLOAT,  "l", "luminance", offsetof(Arguments, luminance), nullptr, "legacy peak brightness (cd/m^2)" },
 	{ OPTION_USER1,  "k", "key",       offsetof(Arguments, mask_key),  decode_mask_key, "HDR color key (RRGGBB hex string)" },
 	{ OPTION_STRING, "m", "mask",      offsetof(Arguments, hdrpath),   nullptr, "HDR difference mask" },
+	{ OPTION_STRING, "s", "sceneref",  offsetof(Arguments, hdrpath),   nullptr, "use scene-referred transfer functions" },
 	{ OPTION_NULL }
 };
 
@@ -241,6 +243,7 @@ void execute(const Arguments &args)
 	zimgxx::zfilter_graph_builder_params params;
 	params.nominal_peak_luminance = args.luminance;
 	params.allow_approximate_gamma = !!args.fast;
+	params.use_scene_referred = !!args.scene_referred;
 
 	// HDR10 specification.
 	zimgxx::zimage_format src_format;

--- a/src/zimg/api/zimg.cpp
+++ b/src/zimg/api/zimg.cpp
@@ -459,6 +459,9 @@ zimg::graph::GraphBuilder::params import_graph_params(const zimg_graph_builder_p
 		params.peak_luminance = src.nominal_peak_luminance;
 		params.approximate_gamma = !!src.allow_approximate_gamma;
 	}
+	if (src.version >= API_VERSION_2_4) {
+		params.scene_referred = !!src.use_scene_referred;
+	}
 
 	return params;
 }
@@ -708,6 +711,9 @@ void zimg_graph_builder_params_default(zimg_graph_builder_params *ptr, unsigned 
 	if (version >= API_VERSION_2_2) {
 		ptr->nominal_peak_luminance = NAN;
 		ptr->allow_approximate_gamma = 0;
+	}
+	if (version >= API_VERSION_2_4) {
+		ptr->use_scene_referred = 0;
 	}
 }
 

--- a/src/zimg/api/zimg.h
+++ b/src/zimg/api/zimg.h
@@ -632,6 +632,9 @@ typedef struct zimg_graph_builder_params {
 
 	/** Allow evaluating transfer functions at reduced precision (default false). */
 	char allow_approximate_gamma;
+
+	/** Use scene-referred transfer functions (default false).*/
+	char use_scene_referred;
 } zimg_graph_builder_params;
 
 /**


### PR DESCRIPTION
As the title says, adds this param to the public API.

I also edited the test example to include it.
I don't know if you didn't want the changelog to be updated, I can remove it ^^