### PR TITLE
autotools: Fix exporting APIs with mingw toolchain

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,9 @@ include_HEADERS = \
 libzimg_la_SOURCES = dummy.cpp
 libzimg_la_LIBADD = libzimg_internal.la
 libzimg_la_LDFLAGS = -no-undefined -version-info 2
+if HAVE_MINGW
+libzimg_la_LDFLAGS += -export-symbols $(srcdir)/_msvc/zimg.def
+endif
 
 libzimg_internal_la_SOURCES = \
 	graphengine/graphengine/cpuinfo.h \

--- a/_msvc/zimg.def
+++ b/_msvc/zimg.def
@@ -1,4 +1,3 @@
-LIBRARY z
 EXPORTS
 	zimg_get_version_info
 	zimg_get_api_version

--- a/configure.ac
+++ b/configure.ac
@@ -118,7 +118,12 @@ AM_CONDITIONAL([X86SIMD_AVX512], [test "x$enable_x86_simd_avx512" = "xyes"])
 
 AS_CASE([$host_os],
         [cygwin*], [AS_IF([test "x$BITS" = "x32"], [LDFLAGS="-Wl,--kill-at"])],
-        [mingw*],  [AS_IF([test "x$BITS" = "x32"], [LDFLAGS="-Wl,--kill-at"])])
+        [mingw*],  [
+            have_mingw_system=yes
+            AS_IF([test "x$BITS" = "x32"], [LDFLAGS="-Wl,--kill-at"])
+        ])
+
+AM_CONDITIONAL([HAVE_MINGW], [test "x$have_mingw_system" = "xyes"])
 
 AC_CONFIG_FILES([Makefile zimg.pc])
 AC_OUTPUT


### PR DESCRIPTION

    This uses zimg.def file with -export-symbols, libtool's link mode flag.
    Otherwise, gcc exports all the public and private functions in mingw
    environment. But with clang in mingw, no symbols are exported.

