### PR TITLE
fix float32 UV become neutral with arm neon

### DIFF
--- a/src/zimg/resize/arm/resize_impl_neon.cpp
+++ b/src/zimg/resize/arm/resize_impl_neon.cpp
@@ -218,8 +218,8 @@ inline FORCE_INLINE float32x4_t resize_line4_h_f32_neon_xiter(unsigned j, const 
 	{
 		float32x4_t &acc = kk % 2 ? accum1 : accum0;
 
-		float32x4_t c = vdupq_laneq_f32(coeffs, 0);
-		float32x4_t x = vld1q_f32(src_p + 0);
+		float32x4_t c = vdupq_laneq_f32(coeffs, static_cast<int>(kk));
+		float32x4_t x = vld1q_f32(src_p + 4 * static_cast<int>(kk)); 
 		acc = vfmaq_f32(acc, c, x);
 	};
 


### PR DESCRIPTION
In the ARM NEON implementation of horizontal resizing functions for float data, a critical bug that affects the U and V planes during color format conversions was identified.

The issue is in the resize_line4_h_f32_neon_xiter function, where the loop unrolling implementation incorrectly uses fixed indices instead of iteration variables when accessing coefficients and source data. This results in only the first coefficient and first data point used for all calculations in a filter tap group, causing the U and V planes to appear as neutral values.