### PR TITLE
Fix build with GCC 15

### DIFF
--- a/src/testcommon/mmap.cpp
+++ b/src/testcommon/mmap.cpp
@@ -10,6 +10,7 @@
   #include <Windows.h>
 #else
   #include <cerrno>
+  #include <cstdint>
 
   #include <fcntl.h>
   #include <unistd.h>


### PR DESCRIPTION
```
src/testcommon/mmap.cpp: In member function 'void MemoryMappedFile::impl::map_file(const char*, int, int, int)':
src/testcommon/mmap.cpp:273:62: error: 'PTRDIFF_MAX' was not declared in this scope
  273 |                 if ((file_size = posix::get_file_size(fd)) > PTRDIFF_MAX)
      |                                                              ^~~~~~~~~~~
src/testcommon/mmap.cpp:22:1: note: 'PTRDIFF_MAX' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```
