### PR TITLE
Fix for MinGW cross-compile

### DIFF
--- a/src/testcommon/mmap.cpp
+++ b/src/testcommon/mmap.cpp
@@ -7,7 +7,7 @@
 #include <system_error>
 
 #ifdef _WIN32
-  #include <Windows.h>
+  #include <windows.h>
 #else
   #include <cerrno>
   #include <cstdint>

--- a/src/zimg/common/arm/cpuinfo_arm.cpp
+++ b/src/zimg/common/arm/cpuinfo_arm.cpp
@@ -4,7 +4,7 @@
   #define NOMINMAX
   #define STRICT
   #define WIN32_LEAN_AND_MEAN
-  #include <Windows.h>
+  #include <windows.h>
 #elif defined(__linux__)
   #include <sys/auxv.h>
   #include <asm/hwcap.h>


### PR DESCRIPTION
Fixes build failures due to case sensitive header names on Linux. Tested using Fedora MinGW toolchain.