### PR TITLE
Detect the C++ stdlib in use automatically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,19 @@ AS_IF([test "x$enable_debug" = "xyes"],
       [AC_SUBST([DEBUGCFLAGS], ["-O0 -g3 -ggdb"])],
       [AC_SUBST([DEBUGCFLAGS], ["-DNDEBUG"])])
 
-AS_IF([test "x$STL_LIBS" = "x"], [STL_LIBS="-lstdc++"])
+AC_LANG_PUSH([C++])
+AC_MSG_CHECKING(for the C++ standard library)
+AS_IF([test "x$STL_LIBS" = "x"],
+      [
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+          #include <cstddef>
+          #ifndef _LIBCPP_VERSION
+          #error libc++ not in use
+          #endif
+        ], [;])], [STL_LIBS="-lc++"], [STL_LIBS="-lstdc++"])
+      ])
+AC_LANG_POP([C++])
+AC_MSG_RESULT($STL_LIBS)
 AC_SUBST([STL_LIBS], [$STL_LIBS])
 
 ARM="no"


### PR DESCRIPTION
This is a fix for some obscure build issues I've been running into when using cross-compile toolchains. Instead of just leaving the choice of C++ library to the user, it checks to see whether the libc++ version macro is defined, and uses that if so. I've tested it to make sure it gives the correct results on various platforms including Linux, FreeBSD, macOS and MSYS, as well as with Windows cross-compile toolchains using LLVM.