### PR TITLE
Fix build with gcc-15

### DIFF
--- a/src/zimg/graph/filtergraph.cpp
+++ b/src/zimg/graph/filtergraph.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <climits>
+#include <cstdint>
 #include <tuple>
 #include "common/align.h"
 #include "common/except.h"


### PR DESCRIPTION
Fixes:
src/zimg/graph/filtergraph.cpp:28:72: error: 'uintptr_t' does not name a type