### PR TITLE
Add NEON-optimized error diffusion dithering

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,6 +157,7 @@ libneon_la_SOURCES = \
 	src/zimg/colorspace/arm/operation_impl_neon.cpp \
 	src/zimg/depth/arm/depth_convert_neon.cpp \
 	src/zimg/depth/arm/dither_neon.cpp \
+	src/zimg/depth/arm/error_diffusion_neon.cpp \
 	src/zimg/resize/arm/resize_impl_neon.cpp
 
 libneon_la_CXXFLAGS = $(AM_CXXFLAGS) $(NEON_CFLAGS)
@@ -353,6 +354,7 @@ test_unit_test_SOURCES += \
 	test/colorspace/arm/colorspace_neon_test.cpp \
 	test/depth/arm/depth_convert_neon_test.cpp \
 	test/depth/arm/dither_neon_test.cpp \
+	test/depth/arm/error_diffusion_neon_test.cpp \
 	test/resize/arm/resize_impl_neon_test.cpp
 endif # ARMSIMD
 

--- a/_msvc/zimg/zimg.vcxproj
+++ b/_msvc/zimg/zimg.vcxproj
@@ -315,6 +315,7 @@
     <ClCompile Include="..\..\src\zimg\depth\arm\depth_convert_neon.cpp" />
     <ClCompile Include="..\..\src\zimg\depth\arm\dither_arm.cpp" />
     <ClCompile Include="..\..\src\zimg\depth\arm\dither_neon.cpp" />
+    <ClCompile Include="..\..\src\zimg\depth\arm\error_diffusion_neon.cpp" />
     <ClCompile Include="..\..\src\zimg\depth\blue.cpp" />
     <ClCompile Include="..\..\src\zimg\depth\depth.cpp" />
     <ClCompile Include="..\..\src\zimg\depth\depth_convert.cpp" />

--- a/_msvc/zimg/zimg.vcxproj.filters
+++ b/_msvc/zimg/zimg.vcxproj.filters
@@ -413,6 +413,9 @@
     <ClCompile Include="..\..\src\zimg\depth\arm\dither_neon.cpp">
       <Filter>Source Files\depth\arm</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\zimg\depth\arm\error_diffusion_neon.cpp">
+      <Filter>Source Files\depth\arm</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\zimg\resize\arm\resize_impl_arm.cpp">
       <Filter>Source Files\resize\arm</Filter>
     </ClCompile>

--- a/src/zimg/depth/arm/dither_arm.cpp
+++ b/src/zimg/depth/arm/dither_arm.cpp
@@ -3,6 +3,7 @@
 #include "common/cpuinfo.h"
 #include "common/pixel.h"
 #include "common/arm/cpuinfo_arm.h"
+#include "graphengine/filter.h"
 #include "dither_arm.h"
 
 namespace zimg::depth {
@@ -47,6 +48,23 @@ dither_convert_func select_ordered_dither_func_arm(const PixelFormat &pixel_in, 
 	}
 
 	return func;
+}
+
+std::unique_ptr<graphengine::Filter> create_error_diffusion_arm(unsigned width, unsigned height, const PixelFormat &pixel_in, const PixelFormat &pixel_out, CPUClass cpu)
+{
+	ARMCapabilities caps = query_arm_capabilities();
+	std::unique_ptr<graphengine::Filter> ret;
+
+	(void)caps;
+
+	if (cpu_is_autodetect(cpu)) {
+		ret = create_error_diffusion_neon(width, height, pixel_in, pixel_out);
+	} else {
+		if (!ret && cpu >= CPUClass::ARM_NEON)
+			ret = create_error_diffusion_neon(width, height, pixel_in, pixel_out);
+	}
+
+	return ret;
 }
 
 } // namespace zimg::depth

--- a/src/zimg/depth/arm/dither_arm.h
+++ b/src/zimg/depth/arm/dither_arm.h
@@ -27,6 +27,10 @@ DECLARE_ORDERED_DITHER(f2w, neon);
 
 dither_convert_func select_ordered_dither_func_arm(const PixelFormat &pixel_in, const PixelFormat &pixel_out, CPUClass cpu);
 
+std::unique_ptr<graphengine::Filter> create_error_diffusion_neon(unsigned width, unsigned height, const PixelFormat &pixel_in, const PixelFormat &pixel_out);
+
+std::unique_ptr<graphengine::Filter> create_error_diffusion_arm(unsigned width, unsigned height, const PixelFormat &pixel_in, const PixelFormat &pixel_out, CPUClass cpu);
+
 } // namespace zimg::depth
 
 #endif // ZIMG_DEPTH_ARM_DITHER_ARM_H_

--- a/src/zimg/depth/arm/error_diffusion_neon.cpp
+++ b/src/zimg/depth/arm/error_diffusion_neon.cpp
@@ -1,0 +1,600 @@
+#ifdef ZIMG_ARM
+
+#include <algorithm>
+#include <climits>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <arm_neon.h>
+#include "common/align.h"
+#include "common/ccdep.h"
+#include "common/checked_int.h"
+#include "common/except.h"
+#include "common/pixel.h"
+#include "common/zassert.h"
+#include "depth/quantize.h"
+#include "graph/filter_base.h"
+#include "dither_arm.h"
+
+#include "common/arm/neon_util.h"
+
+namespace zimg::depth {
+
+namespace {
+
+template <class T>
+struct Buffer {
+	const graphengine::BufferDescriptor &buffer;
+
+	Buffer(const graphengine::BufferDescriptor &buffer) : buffer{ buffer } {}
+
+	T *operator[](unsigned i) const { return buffer.get_line<T>(i); }
+};
+
+
+struct error_state {
+	float err_left[8];
+	float err_top_right[8];
+	float err_top[8];
+	float err_top_left[8];
+};
+
+
+template <PixelType Type>
+struct error_diffusion_traits;
+
+template <>
+struct error_diffusion_traits<PixelType::BYTE> {
+	typedef uint8_t type;
+
+	static float load1(const uint8_t *ptr) { return *ptr; }
+	static void store1(uint8_t *ptr, uint32_t x) { *ptr = static_cast<uint8_t>(x); }
+
+	static void load8(const uint8_t *ptr, float32x4_t &lo, float32x4_t &hi)
+	{
+		uint16x8_t x_w = vmovl_u8(vld1_u8(ptr));
+		lo = vcvtq_f32_u32(vmovl_u16(vget_low_u16(x_w)));
+		hi = vcvtq_f32_u32(vmovl_u16(vget_high_u16(x_w)));
+	}
+
+	static void store8(uint8_t *ptr, uint16x8_t x)
+	{
+		vst1_u8(ptr, vmovn_u16(x));
+	}
+};
+
+template <>
+struct error_diffusion_traits<PixelType::WORD> {
+	typedef uint16_t type;
+
+	static float load1(const uint16_t *ptr) { return *ptr; }
+	static void store1(uint16_t *ptr, uint32_t x) { *ptr = static_cast<uint16_t>(x); }
+
+	static void load8(const uint16_t *ptr, float32x4_t &lo, float32x4_t &hi)
+	{
+		uint16x8_t x = vld1q_u16(ptr);
+		lo = vcvtq_f32_u32(vmovl_u16(vget_low_u16(x)));
+		hi = vcvtq_f32_u32(vmovl_u16(vget_high_u16(x)));
+	}
+
+	static void store8(uint16_t *ptr, uint16x8_t x)
+	{
+		vst1q_u16(ptr, x);
+	}
+};
+
+template <>
+struct error_diffusion_traits<PixelType::HALF> {
+	typedef uint16_t type;
+
+	static float load1(const uint16_t *ptr)
+	{
+		float16x4_t x = vreinterpret_f16_u16(vdup_n_u16(*ptr));
+		return vgetq_lane_f32(vcvt_f32_f16(x), 0);
+	}
+
+	static void load8(const uint16_t *ptr, float32x4_t &lo, float32x4_t &hi)
+	{
+		float16x8_t x = vreinterpretq_f16_u16(vld1q_u16(ptr));
+		lo = vcvt_f32_f16(vget_low_f16(x));
+		hi = vcvt_f32_f16(vget_high_f16(x));
+	}
+};
+
+template <>
+struct error_diffusion_traits<PixelType::FLOAT> {
+	typedef float type;
+
+	static float load1(const float *ptr) { return *ptr; }
+
+	static void load8(const float *ptr, float32x4_t &lo, float32x4_t &hi)
+	{
+		lo = vld1q_f32(ptr + 0);
+		hi = vld1q_f32(ptr + 4);
+	}
+};
+
+
+template <PixelType SrcType, PixelType DstType>
+void error_diffusion_scalar(const void *src, void *dst, const float * RESTRICT error_top, float * RESTRICT error_cur,
+                            float scale, float offset, unsigned bits, unsigned width)
+{
+	typedef error_diffusion_traits<SrcType> src_traits;
+	typedef error_diffusion_traits<DstType> dst_traits;
+
+	const typename src_traits::type *src_p = static_cast<const typename src_traits::type *>(src);
+	typename dst_traits::type *dst_p = static_cast<typename dst_traits::type *>(dst);
+
+	const float max_val = static_cast<float>((1UL << bits) - 1);
+
+	float err_left = error_cur[0];
+	float err_top_right;
+	float err_top = error_top[0 + 1];
+	float err_top_left = error_top[0];
+
+	for (unsigned j = 0; j < width; ++j) {
+		// Error array is padded by one on each side.
+		unsigned j_err = j + 1;
+		err_top_right = error_top[j_err + 1];
+
+		float x = std::fma(src_traits::load1(src_p + j), scale, offset);
+		float err0, err1, err;
+
+		err0 = err_left * (7.0f / 16.0f);
+		err0 = std::fma(err_top_right, 3.0f / 16.0f, err0);
+		err1 = err_top * (5.0f / 16.0f);
+		err1 = std::fma(err_top_left, 1.0f / 16.0f, err1);
+		err = err0 + err1;
+
+		x += err;
+		x = std::clamp(x, 0.0f, max_val);
+
+		uint32_t q = static_cast<uint32_t>(std::lrint(x));
+		err = x - static_cast<float>(q);
+
+		dst_traits::store1(dst_p + j, q);
+		error_cur[j_err] = err;
+
+		err_left = err;
+		err_top_left = err_top;
+		err_top = err_top_right;
+	}
+}
+
+auto select_error_diffusion_scalar_func(PixelType pixel_in, PixelType pixel_out)
+{
+	if (pixel_in == PixelType::BYTE && pixel_out == PixelType::BYTE)
+		return error_diffusion_scalar<PixelType::BYTE, PixelType::BYTE>;
+	else if (pixel_in == PixelType::BYTE && pixel_out == PixelType::WORD)
+		return error_diffusion_scalar<PixelType::BYTE, PixelType::WORD>;
+	else if (pixel_in == PixelType::WORD && pixel_out == PixelType::BYTE)
+		return error_diffusion_scalar<PixelType::WORD, PixelType::BYTE>;
+	else if (pixel_in == PixelType::WORD && pixel_out == PixelType::WORD)
+		return error_diffusion_scalar<PixelType::WORD, PixelType::WORD>;
+	else if (pixel_in == PixelType::HALF && pixel_out == PixelType::BYTE)
+		return error_diffusion_scalar<PixelType::HALF, PixelType::BYTE>;
+	else if (pixel_in == PixelType::HALF && pixel_out == PixelType::WORD)
+		return error_diffusion_scalar<PixelType::HALF, PixelType::WORD>;
+	else if (pixel_in == PixelType::FLOAT && pixel_out == PixelType::BYTE)
+		return error_diffusion_scalar<PixelType::FLOAT, PixelType::BYTE>;
+	else if (pixel_in == PixelType::FLOAT && pixel_out == PixelType::WORD)
+		return error_diffusion_scalar<PixelType::FLOAT, PixelType::WORD>;
+	else
+		error::throw_<error::InternalError>("no conversion between pixel types");
+}
+
+
+struct wf_error_state {
+	float32x4_t err_left_lo;
+	float32x4_t err_left_hi;
+	float32x4_t err_top_right_lo;
+	float32x4_t err_top_right_hi;
+	float32x4_t err_top_lo;
+	float32x4_t err_top_hi;
+	float32x4_t err_top_left_lo;
+	float32x4_t err_top_left_hi;
+};
+
+inline FORCE_INLINE uint16x8_t error_diffusion_wf_neon_xiter(float32x4_t v_lo, float32x4_t v_hi, unsigned j,
+                                                             const float *error_top, float *error_cur, const float *error_top_end, const float32x4_t &max_val,
+                                                             const float32x4_t &err_left_w, const float32x4_t &err_top_right_w,
+                                                             const float32x4_t &err_top_w, const float32x4_t &err_top_left_w,
+                                                             const uint16x8_t &out_max, wf_error_state &state)
+{
+	unsigned j_err = j + 1;
+
+	float32x4_t err0_lo, err0_hi, err1_lo, err1_hi;
+
+	err0_lo = vmulq_f32(state.err_left_lo, err_left_w);
+	err0_lo = vfmaq_f32(err0_lo, state.err_top_right_lo, err_top_right_w);
+	err1_lo = vmulq_f32(state.err_top_lo, err_top_w);
+	err1_lo = vfmaq_f32(err1_lo, state.err_top_left_lo, err_top_left_w);
+	err0_lo = vaddq_f32(err0_lo, err1_lo);
+
+	err0_hi = vmulq_f32(state.err_left_hi, err_left_w);
+	err0_hi = vfmaq_f32(err0_hi, state.err_top_right_hi, err_top_right_w);
+	err1_hi = vmulq_f32(state.err_top_hi, err_top_w);
+	err1_hi = vfmaq_f32(err1_hi, state.err_top_left_hi, err_top_left_w);
+	err0_hi = vaddq_f32(err0_hi, err1_hi);
+
+	float32x4_t x_lo = vaddq_f32(v_lo, err0_lo);
+	float32x4_t x_hi = vaddq_f32(v_hi, err0_hi);
+
+	x_lo = vmaxq_f32(x_lo, vdupq_n_f32(0.0f));
+	x_hi = vmaxq_f32(x_hi, vdupq_n_f32(0.0f));
+
+	x_lo = vminq_f32(x_lo, max_val);
+	x_hi = vminq_f32(x_hi, max_val);
+
+	uint32x4_t q_lo = vcvtnq_u32_f32(x_lo);
+	uint32x4_t q_hi = vcvtnq_u32_f32(x_hi);
+
+	float32x4_t y_lo = vcvtq_f32_u32(q_lo);
+	float32x4_t y_hi = vcvtq_f32_u32(q_hi);
+
+	err0_lo = vsubq_f32(x_lo, y_lo);
+	err0_hi = vsubq_f32(x_hi, y_hi);
+
+	// Left-rotate err0 by 32 bits.
+	float32x4_t err_rot_lo = vextq_f32(err0_hi, err0_lo, 3);
+	float32x4_t err_rot_hi = vextq_f32(err0_lo, err0_hi, 3);
+
+	// Extract the previous high error.
+	vst1q_lane_f32(error_cur + j_err + 0, err_rot_lo, 0);
+
+	// Insert the next error into the low position.
+	{
+		unsigned idx = j_err + 16;
+		const float *next_err = error_top + idx;
+		err_rot_lo = vsetq_lane_f32(next_err < error_top_end ? *next_err : 0.0f, err_rot_lo, 0);
+	}
+
+	uint16x8_t q = vqmovn_high_u32(vqmovn_u32(q_lo), q_hi);
+	q = vminq_u16(q, out_max);
+
+	state.err_left_lo = err0_lo;
+	state.err_left_hi = err0_hi;
+	state.err_top_left_lo = state.err_top_lo;
+	state.err_top_left_hi = state.err_top_hi;
+	state.err_top_lo = state.err_top_right_lo;
+	state.err_top_hi = state.err_top_right_hi;
+	state.err_top_right_lo = err_rot_lo;
+	state.err_top_right_hi = err_rot_hi;
+
+	return q;
+}
+
+template <PixelType SrcType, PixelType DstType, class T, class U>
+void error_diffusion_wf_neon(const Buffer<const T> &src, const Buffer<U> &dst, unsigned i,
+                             const float *error_top, float *error_cur, const float *error_top_end,
+                             error_state *state, float scale, float offset, unsigned bits, unsigned width)
+{
+	typedef error_diffusion_traits<SrcType> src_traits;
+	typedef error_diffusion_traits<DstType> dst_traits;
+
+	typedef typename src_traits::type src_type;
+	typedef typename dst_traits::type dst_type;
+
+	static_assert(std::is_same_v<T, src_type>);
+	static_assert(std::is_same_v<U, dst_type>);
+
+	const float32x4_t err_left_w = vdupq_n_f32(7.0f / 16.0f);
+	const float32x4_t err_top_right_w = vdupq_n_f32(3.0f / 16.0f);
+	const float32x4_t err_top_w = vdupq_n_f32(5.0f / 16.0f);
+	const float32x4_t err_top_left_w = vdupq_n_f32(1.0f / 16.0f);
+
+	const float32x4_t scale_ps = vdupq_n_f32(scale);
+	const float32x4_t offset_ps = vdupq_n_f32(offset);
+	const float32x4_t max_val = vdupq_n_f32(static_cast<float>((1UL << bits) - 1));
+	const uint16x8_t out_max = vdupq_n_u16(static_cast<uint16_t>((1UL << bits) - 1));
+
+	wf_error_state st{};
+	st.err_left_lo = vld1q_f32(state->err_left + 0);
+	st.err_left_hi = vld1q_f32(state->err_left + 4);
+	st.err_top_right_lo = vld1q_f32(state->err_top_right + 0);
+	st.err_top_right_hi = vld1q_f32(state->err_top_right + 4);
+	st.err_top_lo = vld1q_f32(state->err_top + 0);
+	st.err_top_hi = vld1q_f32(state->err_top + 4);
+	st.err_top_left_lo = vld1q_f32(state->err_top_left + 0);
+	st.err_top_left_hi = vld1q_f32(state->err_top_left + 4);
+
+	for (unsigned j = 0; j < width; j += 8) {
+		float32x4_t row_lo[8];
+		float32x4_t row_hi[8];
+
+		src_traits::load8(src[i + 0] + j + 14, row_lo[0], row_hi[0]);
+		src_traits::load8(src[i + 1] + j + 12, row_lo[1], row_hi[1]);
+		src_traits::load8(src[i + 2] + j + 10, row_lo[2], row_hi[2]);
+		src_traits::load8(src[i + 3] + j + 8, row_lo[3], row_hi[3]);
+		src_traits::load8(src[i + 4] + j + 6, row_lo[4], row_hi[4]);
+		src_traits::load8(src[i + 5] + j + 4, row_lo[5], row_hi[5]);
+		src_traits::load8(src[i + 6] + j + 2, row_lo[6], row_hi[6]);
+		src_traits::load8(src[i + 7] + j + 0, row_lo[7], row_hi[7]);
+
+		for (unsigned k = 0; k < 8; ++k) {
+			row_lo[k] = vfmaq_f32(offset_ps, row_lo[k], scale_ps);
+			row_hi[k] = vfmaq_f32(offset_ps, row_hi[k], scale_ps);
+		}
+
+		neon_transpose4_f32(row_lo[0], row_lo[1], row_lo[2], row_lo[3]);
+		neon_transpose4_f32(row_lo[4], row_lo[5], row_lo[6], row_lo[7]);
+		neon_transpose4_f32(row_hi[0], row_hi[1], row_hi[2], row_hi[3]);
+		neon_transpose4_f32(row_hi[4], row_hi[5], row_hi[6], row_hi[7]);
+
+		const float32x4_t diag_lo[8] = { row_lo[0], row_lo[1], row_lo[2], row_lo[3], row_hi[0], row_hi[1], row_hi[2], row_hi[3] };
+		const float32x4_t diag_hi[8] = { row_lo[4], row_lo[5], row_lo[6], row_lo[7], row_hi[4], row_hi[5], row_hi[6], row_hi[7] };
+
+#define XITER error_diffusion_wf_neon_xiter
+#define XARGS error_top, error_cur, error_top_end, max_val, err_left_w, err_top_right_w, err_top_w, err_top_left_w, out_max, st
+		uint16x8_t out0 = XITER(diag_lo[0], diag_hi[0], j + 0, XARGS);
+		uint16x8_t out1 = XITER(diag_lo[1], diag_hi[1], j + 1, XARGS);
+		uint16x8_t out2 = XITER(diag_lo[2], diag_hi[2], j + 2, XARGS);
+		uint16x8_t out3 = XITER(diag_lo[3], diag_hi[3], j + 3, XARGS);
+		uint16x8_t out4 = XITER(diag_lo[4], diag_hi[4], j + 4, XARGS);
+		uint16x8_t out5 = XITER(diag_lo[5], diag_hi[5], j + 5, XARGS);
+		uint16x8_t out6 = XITER(diag_lo[6], diag_hi[6], j + 6, XARGS);
+		uint16x8_t out7 = XITER(diag_lo[7], diag_hi[7], j + 7, XARGS);
+#undef XITER
+#undef XARGS
+
+		neon_transpose8_u16(out0, out1, out2, out3, out4, out5, out6, out7);
+
+		dst_traits::store8(dst[i + 0] + j + 14, out0);
+		dst_traits::store8(dst[i + 1] + j + 12, out1);
+		dst_traits::store8(dst[i + 2] + j + 10, out2);
+		dst_traits::store8(dst[i + 3] + j + 8, out3);
+		dst_traits::store8(dst[i + 4] + j + 6, out4);
+		dst_traits::store8(dst[i + 5] + j + 4, out5);
+		dst_traits::store8(dst[i + 6] + j + 2, out6);
+		dst_traits::store8(dst[i + 7] + j + 0, out7);
+	}
+
+	vst1q_f32(state->err_left + 0, st.err_left_lo);
+	vst1q_f32(state->err_left + 4, st.err_left_hi);
+	vst1q_f32(state->err_top_right + 0, st.err_top_right_lo);
+	vst1q_f32(state->err_top_right + 4, st.err_top_right_hi);
+	vst1q_f32(state->err_top + 0, st.err_top_lo);
+	vst1q_f32(state->err_top + 4, st.err_top_hi);
+	vst1q_f32(state->err_top_left + 0, st.err_top_left_lo);
+	vst1q_f32(state->err_top_left + 4, st.err_top_left_hi);
+}
+
+template <PixelType SrcType, PixelType DstType>
+void error_diffusion_neon(const Buffer<const void> &src_, const Buffer<void> &dst_, unsigned i,
+                          const float *error_top, float *error_cur, float scale, float offset, unsigned bits, unsigned width)
+{
+	typedef error_diffusion_traits<SrcType> src_traits;
+	typedef error_diffusion_traits<DstType> dst_traits;
+
+	typedef typename src_traits::type src_type;
+	typedef typename dst_traits::type dst_type;
+
+	Buffer<const src_type> src{ src_.buffer };
+	Buffer<dst_type> dst{ dst_.buffer };
+
+	error_state state alignas(16) = {};
+	float error_tmp[7][24] = {};
+
+	// Prologue.
+	error_diffusion_scalar<SrcType, DstType>(src[i + 0], dst[i + 0], error_top, error_tmp[0], scale, offset, bits, 14);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 1], dst[i + 1], error_tmp[0], error_tmp[1], scale, offset, bits, 12);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 2], dst[i + 2], error_tmp[1], error_tmp[2], scale, offset, bits, 10);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 3], dst[i + 3], error_tmp[2], error_tmp[3], scale, offset, bits, 8);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 4], dst[i + 4], error_tmp[3], error_tmp[4], scale, offset, bits, 6);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 5], dst[i + 5], error_tmp[4], error_tmp[5], scale, offset, bits, 4);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 6], dst[i + 6], error_tmp[5], error_tmp[6], scale, offset, bits, 2);
+
+	// Wavefront.
+	state.err_left[0] = error_tmp[0][13 + 1];
+	state.err_left[1] = error_tmp[1][11 + 1];
+	state.err_left[2] = error_tmp[2][9 + 1];
+	state.err_left[3] = error_tmp[3][7 + 1];
+	state.err_left[4] = error_tmp[4][5 + 1];
+	state.err_left[5] = error_tmp[5][3 + 1];
+	state.err_left[6] = error_tmp[6][1 + 1];
+	state.err_left[7] = 0.0f;
+
+	state.err_top_right[0] = error_top[15 + 1];
+	state.err_top_right[1] = error_tmp[0][13 + 1];
+	state.err_top_right[2] = error_tmp[1][11 + 1];
+	state.err_top_right[3] = error_tmp[2][9 + 1];
+	state.err_top_right[4] = error_tmp[3][7 + 1];
+	state.err_top_right[5] = error_tmp[4][5 + 1];
+	state.err_top_right[6] = error_tmp[5][3 + 1];
+	state.err_top_right[7] = error_tmp[6][1 + 1];
+
+	state.err_top[0] = error_top[14 + 1];
+	state.err_top[1] = error_tmp[0][12 + 1];
+	state.err_top[2] = error_tmp[1][10 + 1];
+	state.err_top[3] = error_tmp[2][8 + 1];
+	state.err_top[4] = error_tmp[3][6 + 1];
+	state.err_top[5] = error_tmp[4][4 + 1];
+	state.err_top[6] = error_tmp[5][2 + 1];
+	state.err_top[7] = error_tmp[6][0 + 1];
+
+	state.err_top_left[0] = error_top[13 + 1];
+	state.err_top_left[1] = error_tmp[0][11 + 1];
+	state.err_top_left[2] = error_tmp[1][9 + 1];
+	state.err_top_left[3] = error_tmp[2][7 + 1];
+	state.err_top_left[4] = error_tmp[3][5 + 1];
+	state.err_top_left[5] = error_tmp[4][3 + 1];
+	state.err_top_left[6] = error_tmp[5][1 + 1];
+	state.err_top_left[7] = 0.0f;
+
+	unsigned vec_count = floor_n(width - 14, 8);
+	error_diffusion_wf_neon<SrcType, DstType>(src, dst, i, error_top, error_cur, error_top + (width + 2), &state, scale, offset, bits, vec_count);
+
+	error_tmp[0][13 + 1] = state.err_top_right[1];
+	error_tmp[0][12 + 1] = state.err_top[1];
+	error_tmp[0][11 + 1] = state.err_top_left[1];
+
+	error_tmp[1][11 + 1] = state.err_top_right[2];
+	error_tmp[1][10 + 1] = state.err_top[2];
+	error_tmp[1][9 + 1] = state.err_top_left[2];
+
+	error_tmp[2][9 + 1] = state.err_top_right[3];
+	error_tmp[2][8 + 1] = state.err_top[3];
+	error_tmp[2][7 + 1] = state.err_top_left[3];
+
+	error_tmp[3][7 + 1] = state.err_top_right[4];
+	error_tmp[3][6 + 1] = state.err_top[4];
+	error_tmp[3][5 + 1] = state.err_top_left[4];
+
+	error_tmp[4][5 + 1] = state.err_top_right[5];
+	error_tmp[4][4 + 1] = state.err_top[5];
+	error_tmp[4][3 + 1] = state.err_top_left[5];
+
+	error_tmp[5][3 + 1] = state.err_top_right[6];
+	error_tmp[5][2 + 1] = state.err_top[6];
+	error_tmp[5][1 + 1] = state.err_top_left[6];
+
+	error_tmp[6][1 + 1] = state.err_top_right[7];
+	error_tmp[6][0 + 1] = state.err_top[7];
+	error_tmp[6][0] = state.err_top_left[7];
+
+	// Epilogue.
+	error_diffusion_scalar<SrcType, DstType>(src[i + 0] + vec_count + 14, dst[i + 0] + vec_count + 14, error_top + vec_count + 14, error_tmp[0] + 14,
+	                                        scale, offset, bits, width - vec_count - 14);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 1] + vec_count + 12, dst[i + 1] + vec_count + 12, error_tmp[0] + 12, error_tmp[1] + 12,
+	                                        scale, offset, bits, width - vec_count - 12);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 2] + vec_count + 10, dst[i + 2] + vec_count + 10, error_tmp[1] + 10, error_tmp[2] + 10,
+	                                        scale, offset, bits, width - vec_count - 10);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 3] + vec_count + 8, dst[i + 3] + vec_count + 8, error_tmp[2] + 8, error_tmp[3] + 8,
+	                                        scale, offset, bits, width - vec_count - 8);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 4] + vec_count + 6, dst[i + 4] + vec_count + 6, error_tmp[3] + 6, error_tmp[4] + 6,
+	                                        scale, offset, bits, width - vec_count - 6);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 5] + vec_count + 4, dst[i + 5] + vec_count + 4, error_tmp[4] + 4, error_tmp[5] + 4,
+	                                        scale, offset, bits, width - vec_count - 4);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 6] + vec_count + 2, dst[i + 6] + vec_count + 2, error_tmp[5] + 2, error_tmp[6] + 2,
+	                                        scale, offset, bits, width - vec_count - 2);
+	error_diffusion_scalar<SrcType, DstType>(src[i + 7] + vec_count + 0, dst[i + 7] + vec_count + 0, error_tmp[6] + 0, error_cur + vec_count + 0,
+	                                        scale, offset, bits, width - vec_count - 0);
+}
+
+auto select_error_diffusion_neon_func(PixelType pixel_in, PixelType pixel_out)
+{
+	if (pixel_in == PixelType::BYTE && pixel_out == PixelType::BYTE)
+		return error_diffusion_neon<PixelType::BYTE, PixelType::BYTE>;
+	else if (pixel_in == PixelType::BYTE && pixel_out == PixelType::WORD)
+		return error_diffusion_neon<PixelType::BYTE, PixelType::WORD>;
+	else if (pixel_in == PixelType::WORD && pixel_out == PixelType::BYTE)
+		return error_diffusion_neon<PixelType::WORD, PixelType::BYTE>;
+	else if (pixel_in == PixelType::WORD && pixel_out == PixelType::WORD)
+		return error_diffusion_neon<PixelType::WORD, PixelType::WORD>;
+	else if (pixel_in == PixelType::HALF && pixel_out == PixelType::BYTE)
+		return error_diffusion_neon<PixelType::HALF, PixelType::BYTE>;
+	else if (pixel_in == PixelType::HALF && pixel_out == PixelType::WORD)
+		return error_diffusion_neon<PixelType::HALF, PixelType::WORD>;
+	else if (pixel_in == PixelType::FLOAT && pixel_out == PixelType::BYTE)
+		return error_diffusion_neon<PixelType::FLOAT, PixelType::BYTE>;
+	else if (pixel_in == PixelType::FLOAT && pixel_out == PixelType::WORD)
+		return error_diffusion_neon<PixelType::FLOAT, PixelType::WORD>;
+	else
+		error::throw_<error::InternalError>("no conversion between pixel types");
+}
+
+
+class ErrorDiffusionNEON : public graph::FilterBase {
+	decltype(select_error_diffusion_scalar_func({}, {})) m_scalar_func;
+	decltype(select_error_diffusion_neon_func({}, {})) m_neon_func;
+
+	float m_scale;
+	float m_offset;
+	unsigned m_depth;
+
+	void process_scalar(void *ctx, const void *src, void *dst, bool parity) const
+	{
+		float *ctx_a = reinterpret_cast<float *>(ctx);
+		float *ctx_b = reinterpret_cast<float *>(static_cast<unsigned char *>(ctx) + m_desc.context_size / 2);
+
+		float *error_top = parity ? ctx_a : ctx_b;
+		float *error_cur = parity ? ctx_b : ctx_a;
+
+		m_scalar_func(src, dst, error_top, error_cur, m_scale, m_offset, m_depth, m_desc.format.width);
+	}
+
+	void process_vector(void *ctx, const graphengine::BufferDescriptor *in, const graphengine::BufferDescriptor *out, unsigned i) const
+	{
+		float *ctx_a = reinterpret_cast<float *>(ctx);
+		float *ctx_b = reinterpret_cast<float *>(static_cast<unsigned char *>(ctx) + m_desc.context_size / 2);
+
+		float *error_top = (i / 8) % 2 ? ctx_a : ctx_b;
+		float *error_cur = (i / 8) % 2 ? ctx_b : ctx_a;
+
+		m_neon_func(*in, *out, i, error_top, error_cur, m_scale, m_offset, m_depth, m_desc.format.width);
+	}
+
+public:
+	ErrorDiffusionNEON(unsigned width, unsigned height, const PixelFormat &pixel_in, const PixelFormat &pixel_out) try :
+		m_scalar_func{ select_error_diffusion_scalar_func(pixel_in.type, pixel_out.type) },
+		m_neon_func{ select_error_diffusion_neon_func(pixel_in.type, pixel_out.type) },
+		m_scale{}, m_offset{}, m_depth{ pixel_out.depth }
+	{
+		zassert_d(width <= pixel_max_width(pixel_in.type), "overflow");
+		zassert_d(width <= pixel_max_width(pixel_out.type), "overflow");
+
+		if (!pixel_is_integer(pixel_out.type))
+			error::throw_<error::InternalError>("cannot dither to non-integer format");
+
+		m_desc.format = { width, height, pixel_size(pixel_out.type) };
+		m_desc.num_deps = 1;
+		m_desc.num_planes = 1;
+		m_desc.step = 8;
+		m_desc.context_size = ((static_cast<checked_size_t>(width) + 2) * sizeof(float) * 2).get();
+
+		m_desc.flags.stateful = 1;
+		m_desc.flags.in_place = pixel_size(pixel_in.type) == pixel_size(pixel_out.type);
+		m_desc.flags.entire_row = 1;
+
+		std::tie(m_scale, m_offset) = get_scale_offset(pixel_in, pixel_out);
+	} catch (const std::overflow_error &) {
+		error::throw_<error::OutOfMemory>();
+	}
+
+	pair_unsigned get_row_deps(unsigned i) const noexcept override
+	{
+		unsigned last = std::min(i, UINT_MAX - 8) + 8;
+		return{ i, std::min(last, m_desc.format.height) };
+	}
+
+	pair_unsigned get_col_deps(unsigned, unsigned) const noexcept override { return{ 0, m_desc.format.width }; }
+
+	void init_context(void *ctx) const noexcept override
+	{
+		std::fill_n(static_cast<unsigned char *>(ctx), m_desc.context_size, 0);
+	}
+
+	void process(const graphengine::BufferDescriptor *in, const graphengine::BufferDescriptor *out, unsigned i, unsigned left, unsigned right,
+	             void *context, void *) const noexcept override
+	{
+		(void)left;
+		(void)right;
+
+		if (m_desc.format.height - i < 8) {
+			bool parity = !!((i / 8) % 2);
+
+			for (unsigned ii = i; ii < m_desc.format.height; ++ii) {
+				process_scalar(context, in->get_line(ii), out->get_line(ii), parity);
+				parity = !parity;
+			}
+		} else {
+			process_vector(context, in, out, i);
+		}
+	}
+};
+
+} // namespace
+
+std::unique_ptr<graphengine::Filter> create_error_diffusion_neon(unsigned width, unsigned height, const PixelFormat &pixel_in, const PixelFormat &pixel_out)
+{
+	if (width < 14)
+		return nullptr;
+
+	return std::make_unique<ErrorDiffusionNEON>(width, height, pixel_in, pixel_out);
+}
+
+} // namespace zimg::depth
+
+#endif // ZIMG_ARM

--- a/src/zimg/depth/dither.cpp
+++ b/src/zimg/depth/dither.cpp
@@ -369,6 +369,10 @@ std::unique_ptr<graphengine::Filter> create_error_diffusion(unsigned width, unsi
 	if (auto ret = create_error_diffusion_x86(width, height, pixel_in, pixel_out, cpu))
 		return ret;
 #endif
+#ifdef ZIMG_ARM
+	if (auto ret = create_error_diffusion_arm(width, height, pixel_in, pixel_out, cpu))
+		return ret;
+#endif
 
 	ErrorDiffusion::ed_func func = nullptr;
 

--- a/test/depth/arm/error_diffusion_neon_test.cpp
+++ b/test/depth/arm/error_diffusion_neon_test.cpp
@@ -1,0 +1,121 @@
+#ifdef ZIMG_ARM
+
+#include <cmath>
+#include "common/cpuinfo.h"
+#include "common/pixel.h"
+#include "common/arm/cpuinfo_arm.h"
+#include "graphengine/filter.h"
+#include "depth/depth.h"
+#include "depth/dither.h"
+
+#include "gtest/gtest.h"
+#include "graphengine/filter_validation.h"
+#include "dynamic_type.h"
+
+namespace {
+
+void test_case(const zimg::PixelFormat &pixel_in, const zimg::PixelFormat &pixel_out, const char *expected_sha1, double expected_snr)
+{
+	const unsigned w = 640;
+	const unsigned h = 480;
+	const zimg::depth::DitherType dither = zimg::depth::DitherType::ERROR_DIFFUSION;
+
+	bool planes[] = { true, false, false, false };
+	zimg::depth::DepthConversion::result result_c = zimg::depth::create_dither(dither, w, h, pixel_in, pixel_out, planes, zimg::CPUClass::NONE);
+	zimg::depth::DepthConversion::result result_neon = zimg::depth::create_dither(dither, w, h, pixel_in, pixel_out, planes, zimg::CPUClass::ARM_NEON);
+	ASSERT_TRUE(result_c.filter_refs[0]);
+	ASSERT_TRUE(result_neon.filter_refs[0]);
+	ASSERT_TRUE(assert_different_dynamic_type(result_c.filter_refs[0], result_neon.filter_refs[0]));
+
+	graphengine::FilterValidation(result_neon.filter_refs[0], { w, h, zimg::pixel_size(pixel_in.type) })
+		.set_input_pixel_format({ pixel_in.depth, zimg::pixel_is_float(pixel_in.type), pixel_in.chroma })
+		.set_output_pixel_format({ pixel_out.depth, zimg::pixel_is_float(pixel_out.type), pixel_out.chroma })
+		.set_reference_filter(result_c.filter_refs[0], expected_snr)
+		.set_sha1(0, expected_sha1)
+		.run();
+}
+
+} // namespace
+
+
+TEST(ErrorDiffusionNeonTest, test_error_diffusion_b2b)
+{
+	zimg::PixelFormat pixel_in{ zimg::PixelType::BYTE, 8, true, false };
+	zimg::PixelFormat pixel_out{ zimg::PixelType::BYTE, 1, true, false };
+
+	const char *expected_sha1 = "7f88314679a06f74d8f361b7eec07a87768ac9f4";
+
+	test_case(pixel_in, pixel_out, expected_sha1, INFINITY);
+}
+
+TEST(ErrorDiffusionNeonTest, test_error_diffusion_b2w)
+{
+	zimg::PixelFormat pixel_in{ zimg::PixelType::BYTE, 8, true, false };
+	zimg::PixelFormat pixel_out{ zimg::PixelType::WORD, 9, true, false };
+
+	const char *expected_sha1 = "db9fe2d13b97bf9f7a717f37985d88ba7b025ae0";
+
+	test_case(pixel_in, pixel_out, expected_sha1, INFINITY);
+}
+
+TEST(ErrorDiffusionNeonTest, test_error_diffusion_w2b)
+{
+	zimg::PixelFormat pixel_in = zimg::PixelType::WORD;
+	zimg::PixelFormat pixel_out = zimg::PixelType::BYTE;
+
+	const char *expected_sha1 = "e78edb136329d34c7f0a7263506351f89912bc4b";
+
+	test_case(pixel_in, pixel_out, expected_sha1, INFINITY);
+}
+
+TEST(ErrorDiffusionNeonTest, test_error_diffusion_w2w)
+{
+	zimg::PixelFormat pixel_in{ zimg::PixelType::WORD, 16, false, false };
+	zimg::PixelFormat pixel_out{ zimg::PixelType::WORD, 10, false, false };
+
+	const char *expected_sha1 = "86397c91f37ec9a671feac8cce2508a6b67181f4";
+
+	test_case(pixel_in, pixel_out, expected_sha1, INFINITY);
+}
+
+TEST(ErrorDiffusionNeonTest, test_error_diffusion_h2b)
+{
+	zimg::PixelFormat pixel_in = zimg::PixelType::HALF;
+	zimg::PixelFormat pixel_out = zimg::PixelType::BYTE;
+
+	const char *expected_sha1 = "17ffbdc53895e2576f02f8279264d7c54f723671";
+
+	test_case(pixel_in, pixel_out, expected_sha1, INFINITY);
+}
+
+TEST(ErrorDiffusionNeonTest, test_error_diffusion_h2w)
+{
+	zimg::PixelFormat pixel_in = zimg::PixelType::HALF;
+	zimg::PixelFormat pixel_out = zimg::PixelType::WORD;
+
+	const char *expected_sha1 = "cf92073110b1752ac6a1059229660457c4a9deef";
+
+	test_case(pixel_in, pixel_out, expected_sha1, INFINITY);
+}
+
+TEST(ErrorDiffusionNeonTest, test_error_diffusion_f2b)
+{
+	zimg::PixelFormat pixel_in = zimg::PixelType::FLOAT;
+	zimg::PixelFormat pixel_out = zimg::PixelType::BYTE;
+
+	const char *expected_sha1 = "4ed3a75693d507e93a1cf3550fbad51bfff17c3b";
+
+	test_case(pixel_in, pixel_out, expected_sha1, 50.0);
+}
+
+TEST(ErrorDiffusionNeonTest, test_error_diffusion_f2w)
+{
+	zimg::PixelFormat pixel_in = zimg::PixelType::FLOAT;
+	zimg::PixelFormat pixel_out = zimg::PixelType::WORD;
+
+	const char *expected_sha1 = "c512b5d7e29e6bd073d2ae194cdd1738539b6166";
+
+	test_case(pixel_in, pixel_out, expected_sha1, 90.0);
+}
+
+#endif // ZIMG_ARM


### PR DESCRIPTION
## Overview
Added ARM NEON SIMD optimizations for the error diffusion. 

Closes #217 

## Performance Benchmarks

**Metrics:** Minimum execution time (ns/sample). Lower is better. 

Tested under `-O3` compilation. Disabling compiler vectorization showed parity with the scalar baseline.

### Apple M2 Pro @3.49GHz (Clang 22.1.1)

| Format Conversion | Resolution | Scalar (cycles / sample) | NEON (cycles / sample) | Speedup |
|:---|:---|---:|---:|---:|
| `w2b` (16f -> 8b) | 1920x1080| 47.67 | 4.33 | **11.02x** |
| `w2b` (16f -> 8b) | 1919x1080| 46.84 | 4.29 | **10.88x** |
| `w2w10` (16f -> 10f)| 1920x1080| 47.25 | 4.43 | **10.65x** |
| `w2w10` (16f -> 10f)| 1919x1080 | 46.70 | 4.36 | **10.67x** |
| `h2w10` (16f -> 10f)| 1920x1080| 55.87 | 4.33 | **12.86x** |
| `h2w10` (16f -> 10f)| 1919x1080| 55.67 | 4.29 | **12.95x** |
| `f2w10` (32f -> 10f)| 1920x1080| 46.91 | 4.43 | **10.62x** |
| `f2w10` (32f -> 10f)| 1919x1080| 46.66 | 4.40 | **10.62x** |
| **Geomean** | | | | **11.14x** |

### ARM Neoverse-N1 @3GHZ (Clang 18.1.3)

| Format Conversion | Resolution | Scalar (cycles / sample) | NEON (cycles / sample) | Speedup |
|:---|:---|---:|---:|---:|
| `w2b` (16f -> 8b) | 1920x1080| 40.50 | 5.73 | **7.09x** |
| `w2b` (16f -> 8b) | 1919x1080| 40.47 | 5.64 | **7.17x** |
| `w2w10` (16f -> 10f)| 1920x1080| 40.29 | 5.70 | **7.08x** |
| `w2w10` (16f -> 10f)| 1919x1080| 40.35 | 5.67 | **7.13x** |
| `h2w10` (16f -> 10f)| 1920x1080| 45.72 | 5.55 | **8.24x** |
| `h2w10` (16f -> 10f)| 1919x1080| 45.72 | 5.49 | **8.34x** |
| `f2w10` (32f -> 10f)| 1920x1080| 40.41 | 5.43 | **7.45x** |
| `f2w10` (32f -> 10f)| 1919x1080| 40.38 | 5.46 | **7.38x** |
| **Geomean** | | | | **7.47x** |