### PR TITLE
Add RISC-V host detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,9 @@ AS_IF([test "x$enable_unit_test" = "xyes"],
         AS_CASE([$host_cpu],
                 [armv7*],  [],
                 [aarch64], [],
+                [riscv32*], [],
+                [riscv64*], [],
+                [riscv*],   [],
                 [i?86],    [CFLAGS="$CFLAGS -mfpmath=sse -msse2" CXXFLAGS="$CXXFLAGS -mfpmath=sse -msse2"],
                 [x86_64],  [],
                 [AC_MSG_WARN([Could not determine how to enable IEEE-754 compliance on host. Tests may fail.])])
@@ -71,12 +74,19 @@ AC_MSG_RESULT($STL_LIBS)
 AC_SUBST([STL_LIBS], [$STL_LIBS])
 
 ARM="no"
+RISCV="no"
 X86="no"
 
 AS_CASE([$host_cpu],
         [aarch64], [BITS="64" ARM="yes"],
+        [riscv32*], [BITS="32" RISCV="yes"],
+        [riscv64*], [BITS="64" RISCV="yes"],
+        [riscv*], [RISCV="yes"],
         [i?86],    [BITS="32" X86="yes"],
         [x86_64],  [BITS="64" X86="yes"])
+
+AS_IF([test "x$RISCV" = "xyes"],
+      [AC_DEFINE([ZIMG_RISCV], [1], [Define to 1 when building for RISC-V.])])
 
 AS_IF([test "x$ARM" = "xyes" && test "x$enable_simd" != "xno"],
       [


### PR DESCRIPTION
## Why

zimg did not recognize RISC-V autotools hosts explicitly, so riscv builds relied on generic host fallback and did not record a dedicated target macro. This patch makes the baseline RISC-V host path explicit while preserving the current portable implementation.

## What changed

- Detect `riscv32*`, `riscv64*`, and generic `riscv*` autotools hosts.
- Define `ZIMG_RISCV` for RISC-V builds.
- Treat RISC-V as an IEEE-754-capable unit-test host, matching the existing no-extra-flags handling for ARM64 and x86_64.
- Keep RISC-V on the existing portable C++ implementation path instead of enabling x86 AVX/AVX-512 or ARM NEON sources.

## Verification

- Generated autotools files in a temporary verification copy with `autoreconf -i`.
- Ran native portable configuration with `../configure --disable-simd --disable-unit-test --disable-testapp --disable-example`.
- Built the native portable library successfully with `make -j2`.
- Ran simulated RISC-V host configuration with `../configure --host=riscv64-unknown-linux-gnu --disable-unit-test --disable-testapp --disable-example CC=gcc CXX=g++`.
- Confirmed the simulated RISC-V Makefile includes `-DZIMG_RISCV=1`.
- Confirmed the simulated RISC-V Makefile leaves `libneon`, `libavx2`, `libavx512`, and `libavx512_vnni` source and object variables commented out, with only portable library targets active.
- Built the simulated RISC-V portable path successfully with `make -j2`; this used the native compiler with a simulated host alias, not a real RISC-V cross compiler.

## Notes

This is a conservative portability patch. It makes RISC-V an explicit autotools host and keeps zimg on its existing generic implementation path. It does not add RVV kernels, RISC-V-specific CPU feature probing, or true riscv64 hardware validation.